### PR TITLE
Adjust data table header layout

### DIFF
--- a/CSS/custom.css
+++ b/CSS/custom.css
@@ -1,0 +1,24 @@
+.table-header-controls .btn {
+    white-space: nowrap;
+}
+
+.table-header-controls .color-input {
+    width: 120px;
+    min-width: 100px;
+}
+
+@media (max-width: 768px) {
+    #card-table .card-header {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    #card-table .card-header h5 {
+        margin-bottom: 0.5rem;
+    }
+
+    .table-header-controls {
+        width: 100%;
+        justify-content: space-between;
+    }
+}

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
 
     <link href="https://cdn.datatables.net/v/dt/dt-1.13.5/b-2.4.1/b-colvis-2.4.1/b-html5-2.4.1/cr-1.7.0/datatables.min.css" rel="stylesheet"/>
     <link rel="stylesheet" href="https://unpkg.com/huebee@2/dist/huebee.min.css">
+    <link rel="stylesheet" href="CSS/custom.css">
     <title>Data Visualisation App</title>
 </head>
 <body>
@@ -99,11 +100,13 @@
         <div class="row">
             <div class="col-md-6">
                 <div class="card mb-4" id='card-table'>
-                    <div class="card-header d-flex justify-content-between align-items-center">
-                        <h5 class="mb-0" >Data Table</h5>
-                        <button id="search-visible" class="btn btn-primary">Highlight Rows</button>
-                        <input id="colorpicker_value_table" type="text" class="color-input" value="orange" />
-                        <button id="reset-button" class="btn btn-primary">Reset Table</button>
+                    <div class="card-header d-flex align-items-center justify-content-between flex-wrap gap-2">
+                        <h5 class="mb-0 me-3 flex-grow-1 text-start">Data Table</h5>
+                        <div class="table-header-controls d-flex align-items-center gap-2 flex-nowrap">
+                            <button id="search-visible" class="btn btn-primary btn-sm">Highlight Rows</button>
+                            <input id="colorpicker_value_table" type="text" class="color-input form-control form-control-sm" value="orange" />
+                            <button id="reset-button" class="btn btn-primary btn-sm">Reset Table</button>
+                        </div>
                     </div>
                     <div class="card-body">
                         <div class="table-responsive">

--- a/index.html
+++ b/index.html
@@ -76,7 +76,7 @@
                 <div class="card mb-4" id="card-volano-plot">
                     <div class="card-header d-flex justify-content-between align-items-center">
                         <h5 class="mb-0">Volcano Plot</h5>
-                        <button id="download-scatter1" class="btn btn-primary">Download Plot</button>
+                        <button id="download-scatter1" class="btn btn-primary btn-sm">Download Plot</button>
                     </div>
                     <div class="card-body">
                         <svg id="scatterplot1"></svg>
@@ -88,7 +88,7 @@
                 <div class="card mb-4" id='card-ma-plot'>
                     <div class="card-header d-flex justify-content-between align-items-center">
                         <h5 class="mb-0" >MA Plot</h5>
-                        <button id="download-scatter2" class="btn btn-primary">Download Plot</button>
+                        <button id="download-scatter2" class="btn btn-primary btn-sm">Download Plot</button>
                     </div>
                     <div class="card-body">
                         <svg id="scatterplot2"></svg>
@@ -123,7 +123,7 @@
                 <div class="card mb-4" id='card-barplot'>
                     <div class="card-header d-flex justify-content-between align-items-center">
                         <h5 class="mb-0">Intensity Bar Plot</h5>
-                        <button id="download-bar" class="btn btn-primary">Download Plot</button>
+                        <button id="download-bar" class="btn btn-primary btn-sm">Download Plot</button>
 
                     </div>
                     <div class="card-body">


### PR DESCRIPTION
## Summary
- add a custom stylesheet for the data table header controls
- tighten spacing in the data table card header so the buttons stay on one line
- shrink the highlight and reset buttons for a more compact layout

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ecb735f85c83319d47aab61e0a9297