### PR TITLE
Add navbar reset for highlighting controls

### DIFF
--- a/JS/interactivity.js
+++ b/JS/interactivity.js
@@ -183,18 +183,27 @@ function addHilight(table, scatterPlot1, scatterPlot2, updateBarPlot, controlNam
   document.getElementById('myForm').addEventListener('reset', function(e) {
 
     scatterPlot1.selectAll('circle')
-        
+
         .attr('fill', 'steelblue')
         .attr('r', 4).raise();
 
     scatterPlot2.selectAll('circle')
-        
+
         .attr('fill', 'steelblue')
         .attr('r', 4).raise();
 
-    table.search('').columns().search('').draw(); 
-        
+    table.search('').columns().search('').draw();
+
   });
+
+
+  const navbarHighlightResetButton = document.getElementById('navbar-highlight-reset');
+  if (navbarHighlightResetButton) {
+    navbarHighlightResetButton.disabled = false;
+    navbarHighlightResetButton.onclick = function() {
+      document.getElementById('myForm').reset();
+    };
+  }
 
 
   document.getElementById('search-visible').addEventListener('click', function(e) {

--- a/index.html
+++ b/index.html
@@ -56,6 +56,7 @@
             <div class="container-fluid d-flex align-items-center gap-2">
                 <button class="btn btn-secondary" id="uploadTestFile">Upload Test File</button>
                 <a href="example_proteomics.html" target="_blank" rel="noopener noreferrer" class="btn btn-secondary">Visualise analysis pipline</a>
+                <button class="btn btn-secondary" id="navbar-highlight-reset" disabled>Reset Highlights</button>
             </div>
 
 


### PR DESCRIPTION
## Summary
- add a Reset Highlights button to the navbar so users can quickly clear highlighting selections
- enable the button after data load and wire it to the existing form reset behaviour

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ecb7945ad48331986206285d9f1261